### PR TITLE
Fix input tmpfs path in podman-compose configuration

### DIFF
--- a/podman-compose.yml
+++ b/podman-compose.yml
@@ -14,11 +14,11 @@ services:
       - "8188:8188"
     volumes:
       - ./custom_nodes:/workspace/custom_nodes
-      - ./models:/workspace/models        
+      - ./models:/workspace/models
       - ./output:/workspace/output
-      - ./venv:/opt/venv                   
+      - ./venv:/opt/venv
     tmpfs:
-      - /iworkspace/input:size=1G,mode=1777
+      - /workspace/input:size=1G,mode=1777
       - /workspace/temp:size=1G,mode=1777
     deploy:
       resources:


### PR DESCRIPTION
## Summary
- correct typo in tmpfs mount for input directory

------
https://chatgpt.com/codex/tasks/task_e_688e6656521483239c26cac14d470ea2