### PR TITLE
Add HTTPS proxy with basic auth for ComfyUI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,11 @@ output/
 custom_nodes/
 workflows/
 
+# proxy credentials
+nginx/htpasswd
+nginx/certs/*.crt
+nginx/certs/*.key
+
 # python stuff
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,32 @@
 # comfyui-podman-compose
-Run ComfyUI in podman compose
+Run ComfyUI in podman compose behind an `nginx` reverse proxy that
+exposes the service with HTTPS and basic authentication on port `8443`.
+
+## Setup
+
+1. Create a password file (example user `user` with password `changeme`):
+
+   ```sh
+   printf "user:$(openssl passwd -apr1 'changeme')\n" > nginx/htpasswd
+   ```
+
+2. Place a TLS certificate and key in `nginx/certs/server.crt` and
+   `nginx/certs/server.key`. A self-signed certificate for local testing
+   can be generated with:
+
+   ```sh
+   openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
+     -keyout nginx/certs/server.key \
+     -out nginx/certs/server.crt \
+     -subj "/CN=localhost"
+   ```
+
+3. Start the stack:
+
+   ```sh
+   podman-compose up
+   ```
+
+ComfyUI is then available at <https://localhost:8443> and protected by
+the credentials in `nginx/htpasswd`. The certificate and password file
+are ignored by Git for security and must be created locally.

--- a/nginx/certs/README.md
+++ b/nginx/certs/README.md
@@ -1,0 +1,5 @@
+Place your TLS certificate as server.crt and key as server.key in this directory.
+You can generate a self-signed certificate for local testing with:
+
+openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout server.key -out server.crt -subj "/CN=localhost"
+These files are excluded from version control for security.

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,20 @@
+events {}
+
+http {
+  server {
+    listen 443 ssl;
+    server_name _;
+
+    ssl_certificate /etc/nginx/certs/server.crt;
+    ssl_certificate_key /etc/nginx/certs/server.key;
+
+    location / {
+      proxy_pass http://comfyui:8188;
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      auth_basic "Restricted";
+      auth_basic_user_file /etc/nginx/htpasswd;
+    }
+  }
+}

--- a/podman-compose.yml
+++ b/podman-compose.yml
@@ -10,8 +10,8 @@ services:
       - "nvidia.com/gpu=all"      # CDI-Hook hands over the NVIDIA GPU
     security_opt:
       - label=disable             # SELinux can use external paths
-    ports:
-      - "8188:8188"
+    expose:
+      - "8188"
     volumes:
       - ./custom_nodes:/workspace/custom_nodes
       - ./models:/workspace/models        
@@ -28,3 +28,14 @@ services:
         reservations:
           memory: 35g           # OOM-Killer earlier
     restart: "no"
+
+  proxy:
+    image: nginx:alpine
+    depends_on:
+      - comfyui
+    ports:
+      - "8443:443"
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./nginx/htpasswd:/etc/nginx/htpasswd:ro
+      - ./nginx/certs:/etc/nginx/certs:ro


### PR DESCRIPTION
## Summary
- document running ComfyUI behind an nginx HTTPS proxy with basic auth
- add setup steps to create TLS certificate and password file
- keep generated credentials out of version control

## Testing
- `git pull origin main` *(fails: 'origin' does not appear to be a git repository)*
- `apt-get update` *(fails: 403 Forbidden, repository not signed)*
- `apt-get install -y podman podman-compose` *(fails: unable to locate package)*
- `pip install podman-compose` *(fails: Tunnel connection failed: 403 Forbidden)*
- `podman-compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e66cc5c9c8323a7fc0e7082ac0b35