### PR TITLE
Add torchsde dependency to patch requirements

### DIFF
--- a/patch-requirements.txt
+++ b/patch-requirements.txt
@@ -1,1 +1,2 @@
 trampoline==0.1.2
+torchsde==0.2.5


### PR DESCRIPTION
## Summary
- include torchsde in patch-requirements to avoid ModuleNotFoundError

------
https://chatgpt.com/codex/tasks/task_e_688e754a6c9883238ec194924404e89e