### PR TITLE
Allow pinning ComfyUI checkout to specific ref

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,33 @@ Optionally, the ComfyUI instance can be served through an `nginx` reverse proxy 
      ./run_comfy.sh
      ```
    - **Standard (no proxy)** (Port 8188):
-     → ComfyUI is available at <http://localhost:8188>  
+     → ComfyUI is available at <http://localhost:8188>
    - **With nginx reverse proxy** (Port 8443, HTTPS & Auth):
      → ComfyUI is available at <https://localhost:8443> (protected by credentials in `nginx/htpasswd`)
+
+---
+
+## Pinning the ComfyUI Version
+
+The container respects the environment variable `COMFYUI_REF` to select the desired
+branch, tag, or commit of the upstream ComfyUI repository during the initial clone
+and subsequent updates. To pin the deployment to a specific version, pass the build
+argument when (re)building the image and keep the same variable during `up`:
+
+```bash
+COMFYUI_REF=v1.3.3 podman-compose build --build-arg COMFYUI_REF=v1.3.3
+COMFYUI_REF=v1.3.3 podman-compose up -d --force-recreate
+```
+
+Alternatively, export the variable once for the current shell session before running
+`./run_comfy.sh`:
+
+```bash
+export COMFYUI_REF=v1.3.3
+./run_comfy.sh
+```
+
+Omit the variable (or reset it to the default `master`) to follow the upstream default branch again.
 
 ---
 

--- a/dockerfile
+++ b/dockerfile
@@ -13,7 +13,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 ARG UID=1000
 ARG GID=1000
+ARG COMFYUI_REF=master
 RUN groupadd -g $GID comfy && useradd -u $UID -g comfy -m -d $WORKDIR comfy
+ENV COMFYUI_REF=$COMFYUI_REF
 USER comfy
 WORKDIR $WORKDIR
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,7 +11,13 @@ ln -snf /workspace/temp         ComfyUI/temp         2>/dev/null || true
 
 # ---------- 1) sync with github comfyUI code ----------
 if [ -d ComfyUI/.git ]; then
-  git -C ComfyUI pull --ff-only
+  if [ -n "${COMFYUI_REF:-}" ]; then
+    echo "[+] Syncing ComfyUI to ref: $COMFYUI_REF"
+    git -C ComfyUI fetch --depth=1 origin "$COMFYUI_REF"
+    git -C ComfyUI reset --hard FETCH_HEAD
+  else
+    git -C ComfyUI pull --ff-only
+  fi
 else
   echo "[!] Stale ComfyUI dir – räume Code auf"
   mkdir -p ComfyUI
@@ -19,7 +25,12 @@ else
        ! -name custom_nodes ! -name models ! -name output \
        ! -name input ! -name temp \
        -exec rm -rf {} +
-  git clone --depth 1 https://github.com/comfyanonymous/ComfyUI.git ComfyUI_tmp
+  if [ -n "${COMFYUI_REF:-}" ]; then
+    git clone --depth 1 --branch "$COMFYUI_REF" \
+      https://github.com/comfyanonymous/ComfyUI.git ComfyUI_tmp
+  else
+    git clone --depth 1 https://github.com/comfyanonymous/ComfyUI.git ComfyUI_tmp
+  fi
   cp -rT ComfyUI_tmp ComfyUI && rm -rf ComfyUI_tmp
 fi
 


### PR DESCRIPTION
## Summary
- add a COMFYUI_REF build argument and export it at runtime
- adjust the entrypoint to clone or fetch the configured ref instead of always using the default branch
- document how to pin the ComfyUI version via COMFYUI_REF

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f3d7fc80b88323b2c239760d0e09cf