### PR TITLE
Add Mesa and font dependencies for OpenCV

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -9,7 +9,9 @@ ENV DEBIAN_FRONTEND=noninteractive \
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-        git python3 python3-venv python3-pip libglib2.0-0 libgl1 ffmpeg tini \
+        git python3 python3-venv python3-pip ffmpeg tini \
+        # Install Mesa/GL and GLib so OpenCV can load libGL.so.1 for ComfyUI-VideoHelperSuite
+        libglib2.0-0 libgl1 libglx-mesa0 fonts-dejavu-core fontconfig \
     && rm -rf /var/lib/apt/lists/*
 
 ARG UID=1000


### PR DESCRIPTION
## Summary
- add Mesa and font packages to the base image so OpenCV can load libGL
- document the purpose of the new dependencies with an inline comment

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f3e0e920b0832387aa8b98b477eccd