### PR TITLE
Organize Dockerfile blocks and update PATH

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -1,12 +1,16 @@
 # ---------- Stage: base ----------
 FROM nvidia/cuda:12.4.1-runtime-ubuntu22.04
 
+# Configure environment variables and paths
 ENV DEBIAN_FRONTEND=noninteractive \
     PYTHONUNBUFFERED=1 \
     VENV_PATH=/opt/venv \
     WORKDIR=/workspace \
     PATH="/opt/venv/bin:$PATH"
+# make ~/.local/bin available on the PATH so scripts like tqdm, torchrun, etc. are found
+ENV PATH=/home/appuser/.local/bin:$PATH
 
+# Install system dependencies required for ComfyUI
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         git python3 python3-venv python3-pip ffmpeg tini \
@@ -14,6 +18,7 @@ RUN apt-get update \
         libglib2.0-0 libgl1 libglx-mesa0 fonts-dejavu-core fontconfig \
     && rm -rf /var/lib/apt/lists/*
 
+# Configure application user
 ARG UID=1000
 ARG GID=1000
 ARG COMFYUI_REF=master
@@ -26,6 +31,7 @@ ENV COMFYUI_REF=$COMFYUI_REF
 USER comfy
 WORKDIR $WORKDIR
 
+# Copy application entrypoint and dependency patches
 COPY --chown=comfy:comfy entrypoint.sh /entrypoint.sh
 COPY --chown=comfy:comfy patch-requirements.txt /patch-requirements.txt
 ENTRYPOINT ["/usr/bin/tini","--","/entrypoint.sh"]


### PR DESCRIPTION
## Summary
- add descriptive comments to group Dockerfile instructions by purpose
- extend PATH to include /home/appuser/.local/bin for user-installed scripts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f3e23e358c8323b1b344ee9912a87a