### PR TITLE
Add Docker compatibility and OS-specific documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,20 +2,28 @@
 
 ## Introduction
 
-This repository provides a **Podman Compose** setup for running the **ComfyUI** image‑generation interface in a containerized environment with GPU acceleration.  
-Optionally, the service can run behind an `nginx` reverse proxy with **HTTPS** and **Basic Authentication**.
+This repository provides a containerised setup for running the **ComfyUI** image‑generation interface with GPU acceleration.
+It supports both **Podman** and **Docker**, and can optionally serve the UI behind an `nginx` reverse proxy with **HTTPS** and **Basic Authentication**.
 
 ---
 
-## Prerequisites
+## Platform prerequisites
 
-- A Linux host with **Podman** and **Podman Compose** installed.  
-- An **NVIDIA GPU** with driver support.  
-- The **NVIDIA Container Toolkit** (`nvidia-container-toolkit`), which provides the `nvidia-ctk` utility:  
+### Linux (Podman)
+
+- A Linux host with **Podman** (v4.0+) and either the `podman compose` plugin or the standalone **podman-compose** tool installed.
+- An **NVIDIA GPU** with the proprietary driver.
+- The **NVIDIA Container Toolkit** (`nvidia-container-toolkit`) to expose GPUs via CDI:
   ```bash
   sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml
   ```
-  This creates the `nvidia.com/gpu` CDI specification used by the compose file.
+  This generates the `nvidia.com/gpu` CDI specification consumed by the Podman override file.
+
+### Windows (Docker Desktop)
+
+- **Docker Desktop** with the WSL2-based engine enabled.
+- GPU support enabled in Docker Desktop (Settings → Resources → GPU). An NVIDIA GPU with recent drivers is required.
+- Windows Terminal or PowerShell with Git available. When running scripts, execute them from a **Git Bash** or **WSL** shell to ensure POSIX compatibility.
 
 ---
 
@@ -26,6 +34,20 @@ Create these directories in the repository root before starting:
 - `models/`
 - `output/`
 - `venv/`
+
+---
+
+## Engine-specific configuration
+
+### Linux (Podman)
+
+- `docker-compose.yml` is combined with `docker-compose.podman.yml` to inject the CDI GPU device (`nvidia.com/gpu=all`) and disable SELinux relabeling conflicts.
+- Ensure `/etc/cdi/nvidia.yaml` exists (see prerequisites) so that the GPU becomes available inside the container.
+
+### Windows (Docker Desktop)
+
+- Only the base `docker-compose.yml` is used. Docker Desktop maps the GPU automatically when GPU support is enabled in the settings.
+- Volume mounts rely on WSL2 paths. If you run the scripts from PowerShell, ensure the repository lives inside your WSL2 home directory or convert the paths with `wslpath`.
 
 ---
 
@@ -62,8 +84,9 @@ Optionally, the ComfyUI instance can be served through an `nginx` reverse proxy 
 2. Create the required directories listed above.
 3. Start the container:
     ```bash
-     ./run_comfy.sh
-     ```
+    ./run_comfy.sh
+    ```
+   The helper script auto-detects the available container engine. Override the detection with `CONTAINER_ENGINE=docker ./run_comfy.sh` or `CONTAINER_ENGINE=podman ./run_comfy.sh` if multiple engines are installed.
    - **Standard (no proxy)** (Port 8188):
      → ComfyUI is available at <http://localhost:8188>
    - **With nginx reverse proxy** (Port 8443, HTTPS & Auth):
@@ -75,20 +98,15 @@ Optionally, the ComfyUI instance can be served through an `nginx` reverse proxy 
 
 The container respects the environment variable `COMFYUI_REF` to select the desired
 branch, tag, or commit of the upstream ComfyUI repository during the initial clone
-and subsequent updates. To pin the deployment to a specific version, pass the build
-argument when (re)building the image and keep the same variable during `up`:
+and subsequent updates. To pin the deployment to a specific version, export the variable
+before running the helper scripts. Examples:
 
 ```bash
-COMFYUI_REF=v1.3.3 podman-compose build --build-arg COMFYUI_REF=v1.3.3
-COMFYUI_REF=v1.3.3 podman-compose up -d --force-recreate
-```
+# Podman on Linux
+COMFYUI_REF=v1.3.3 CONTAINER_ENGINE=podman ./run_comfy.sh
 
-Alternatively, export the variable once for the current shell session before running
-`./run_comfy.sh`:
-
-```bash
-export COMFYUI_REF=v1.3.3
-./run_comfy.sh
+# Docker Desktop on Windows / WSL
+COMFYUI_REF=v1.3.3 CONTAINER_ENGINE=docker ./run_comfy.sh
 ```
 
 Omit the variable (or reset it to the default `master`) to follow the upstream default branch again.
@@ -100,25 +118,26 @@ Omit the variable (or reset it to the default `master`) to follow the upstream d
 ```bash
 ./kill-comfyui.sh
 ```
-Stops all running ComfyUI containers.
+Stops the running ComfyUI stack using the same container engine that `run_comfy.sh` detected (or the engine specified through `CONTAINER_ENGINE`).
 
 ---
 
 ## Repository Structure
 
-- `podman-compose.yml` – Container configuration (GPU access, ports, volumes)
-- `Dockerfile` – Base image and runtime setup
+- `docker-compose.yml` – Base container configuration (GPU access, ports, volumes)
+- `docker-compose.podman.yml` – Podman-specific extensions (CDI GPU device & SELinux labels)
+- `dockerfile` – Base image and runtime setup
 - `entrypoint.sh` – Container entrypoint (symlinks, code checkout, Python virtual environment, launch ComfyUI)
 - Helper scripts:
-  - `run_comfy.sh` – builds image, starts container, follows logs
-  - `kill-comfyui.sh` – stops running containers
+  - `run_comfy.sh` – builds the image, starts the container stack, follows logs (auto-detects Docker vs Podman)
+  - `kill-comfyui.sh` – stops and removes the running stack (auto-detects Docker vs Podman)
   - `clear_podman_cache.sh` – removes Podman cache data
 
 ---
 
 ## Learning Aspects
 
-1. **Containerization with Podman** – building images and running containers  
+1. **Containerization with Podman & Docker** – building images and running containers
 2. **Shell scripting** – automating build, start, and cleanup tasks  
 3. **Python virtual environments** – creating and managing isolated environments  
 4. **GPU configuration** – NVIDIA drivers and container runtime support  

--- a/docker-compose.podman.yml
+++ b/docker-compose.podman.yml
@@ -1,0 +1,6 @@
+services:
+  comfyui:
+    devices:
+      - "nvidia.com/gpu=all"      # Podman CDI hook hands over the NVIDIA GPU
+    security_opt:
+      - label=disable             # Needed on SELinux hosts (ignored elsewhere)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,10 +8,6 @@ services:
       context: .
       dockerfile: dockerfile
     user: "1000:1000"
-    devices:
-      - "nvidia.com/gpu=all"      # Podman CDI hook hands over the NVIDIA GPU
-    security_opt:
-      - label=disable             # Needed on SELinux hosts (ignored elsewhere)
     expose:
       - "8188"
     volumes:

--- a/kill-comfyui.sh
+++ b/kill-comfyui.sh
@@ -1,9 +1,69 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # kill-comfyui.sh
-set -e
-echo ">>> Killing all ComfyUI containers"
-podman ps --filter name=comfyui_ -q | while read cid; do
-    echo "Removing container $cid"
-    podman rm -f --depend $cid || true
-done
+set -euo pipefail
+
+detect_engine() {
+    local engine=${CONTAINER_ENGINE:-}
+
+    if [[ -n ${engine} ]]; then
+        if ! command -v "${engine}" >/dev/null 2>&1; then
+            echo "[!] Requested container engine '${engine}' not found on PATH" >&2
+            exit 1
+        fi
+    else
+        if command -v podman >/dev/null 2>&1; then
+            engine=podman
+        elif command -v docker >/dev/null 2>&1; then
+            engine=docker
+        else
+            echo "[!] Neither podman nor docker is available. Install one of them first." >&2
+            exit 1
+        fi
+    fi
+
+    printf '%s' "${engine}"
+}
+
+detect_compose() {
+    local engine=$1
+
+    if [[ ${engine} == podman ]]; then
+        if podman compose version >/dev/null 2>&1; then
+            COMPOSE_CMD=(podman compose)
+            return
+        elif command -v podman-compose >/dev/null 2>&1; then
+            COMPOSE_CMD=(podman-compose)
+            return
+        fi
+    else
+        if docker compose version >/dev/null 2>&1; then
+            COMPOSE_CMD=(docker compose)
+            return
+        elif command -v docker-compose >/dev/null 2>&1; then
+            COMPOSE_CMD=(docker-compose)
+            return
+        fi
+    fi
+
+    echo "[!] No compose plugin/binary found for '${engine}'." >&2
+    exit 1
+}
+
+ENGINE=$(detect_engine)
+detect_compose "${ENGINE}"
+
+COMPOSE_FILES=(-f docker-compose.yml)
+if [[ ${ENGINE} == podman && -f docker-compose.podman.yml ]]; then
+    COMPOSE_FILES+=(-f docker-compose.podman.yml)
+fi
+
+echo ">>> Stopping ComfyUI stack via ${COMPOSE_CMD[*]}"
+"${COMPOSE_CMD[@]}" "${COMPOSE_FILES[@]}" down --remove-orphans || true
+
+echo ">>> Removing leftover containers (if any)"
+if [[ ${ENGINE} == podman ]]; then
+    "${ENGINE}" rm -f --depend comfyui comfyui-proxy 2>/dev/null || true
+else
+    "${ENGINE}" rm -f comfyui comfyui-proxy 2>/dev/null || true
+fi
 

--- a/run_comfy.sh
+++ b/run_comfy.sh
@@ -1,10 +1,70 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
+
+detect_engine() {
+  local engine=${CONTAINER_ENGINE:-}
+
+  if [[ -n ${engine} ]]; then
+    if ! command -v "${engine}" >/dev/null 2>&1; then
+      echo "[!] Requested container engine '${engine}' not found on PATH" >&2
+      exit 1
+    fi
+  else
+    if command -v podman >/dev/null 2>&1; then
+      engine=podman
+    elif command -v docker >/dev/null 2>&1; then
+      engine=docker
+    else
+      echo "[!] Neither podman nor docker is available. Install one of them first." >&2
+      exit 1
+    fi
+  fi
+
+  printf '%s' "${engine}"
+}
+
+detect_compose() {
+  local engine=$1
+
+  if [[ ${engine} == podman ]]; then
+    if podman compose version >/dev/null 2>&1; then
+      COMPOSE_CMD=(podman compose)
+      return
+    elif command -v podman-compose >/dev/null 2>&1; then
+      COMPOSE_CMD=(podman-compose)
+      return
+    fi
+  else
+    if docker compose version >/dev/null 2>&1; then
+      COMPOSE_CMD=(docker compose)
+      return
+    elif command -v docker-compose >/dev/null 2>&1; then
+      COMPOSE_CMD=(docker-compose)
+      return
+    fi
+  fi
+
+  echo "[!] No compose plugin/binary found for '${engine}'." >&2
+  echo "    Install the matching compose implementation (e.g. docker compose, docker-compose, podman compose, podman-compose)." >&2
+  exit 1
+}
+
+ENGINE=$(detect_engine)
+detect_compose "${ENGINE}"
+
+COMPOSE_FILES=(-f docker-compose.yml)
+if [[ ${ENGINE} == podman && -f docker-compose.podman.yml ]]; then
+  COMPOSE_FILES+=(-f docker-compose.podman.yml)
+fi
+
+echo "[+] Using container engine : ${ENGINE}"
+echo "[+] Using compose command  : ${COMPOSE_CMD[*]}"
+echo "[+] Compose files          : ${COMPOSE_FILES[*]//-f /}"
 
 # Build container image
-podman-compose build
+"${COMPOSE_CMD[@]}" "${COMPOSE_FILES[@]}" build
 
-# Container start & follow Logs
-podman-compose up -d --force-recreate --remove-orphans
-podman logs -f comfyui_comfyui_1
+# Container start & follow logs
+"${COMPOSE_CMD[@]}" "${COMPOSE_FILES[@]}" up -d --force-recreate --remove-orphans
+"${ENGINE}" logs -f comfyui
 


### PR DESCRIPTION
## Summary
- add a Podman-only compose override and update helper scripts to auto-detect Docker or Podman
- document separate Linux (Podman) and Windows (Docker Desktop) setup steps and engine-specific configuration

## Testing
- bash -n run_comfy.sh
- bash -n kill-comfyui.sh

------
https://chatgpt.com/codex/tasks/task_e_68f3ee3d54b88323804f6c6eb85d3efd