### PR TITLE
Upgrade CUDA base image and preinstall torch stack

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,19 +14,16 @@ services:
       - ./custom_nodes:/workspace/custom_nodes
       - ./models:/workspace/models
       - ./output:/workspace/output
-      - ./venv:/opt/venv
       # persist all your settings & extra nodes
       - ./settings:/app/ComfyUI/user/default:rw
       # persist just your saved flows (overrides the workflows/ in default)
       - ./flows:/app/ComfyUI/user/default/workflows:rw
-      # does not dump stuff into the writable layer of the image and inflates it
-      - ./temp_disk:/workspace/temp:rw
-      - ./tmp_disk:/tmp:rw
       # Caches persistent
       - ./cache:/workspace/.cache
       - ./nv:/root/.nv
     tmpfs:
       - /workspace/input:size=1G,mode=1777
+      - /tmp:size=8G,mode=1777
     environment:
       # Caches
       - XDG_CACHE_HOME=/workspace/.cache
@@ -35,12 +32,6 @@ services:
       - HUGGINGFACE_HUB_CACHE=/workspace/.cache/huggingface/hub
       - TORCH_HOME=/workspace/.cache/torch
       - PIP_CACHE_DIR=/workspace/.cache/pip
-      - CUDA_CACHE_PATH=/root/.nv/ComputeCache
-
-      # all systemwide Temp-targets to one location
-      - TMPDIR=/workspace/temp
-      - TEMP=/workspace/temp
-      - TMP=/workspace/temp
     deploy:
       resources:
         limits:

--- a/dockerfile
+++ b/dockerfile
@@ -1,5 +1,5 @@
 # ---------- Stage: base ----------
-FROM nvidia/cuda:12.4.1-runtime-ubuntu22.04
+FROM nvidia/cuda:12.8.1-runtime-ubuntu24.04
 
 # Configure environment variables and paths
 ENV DEBIAN_FRONTEND=noninteractive \
@@ -16,6 +16,7 @@ RUN apt-get update \
         git python3 python3-venv python3-pip ffmpeg tini \
         # Install Mesa/GL and GLib so OpenCV can load libGL.so.1 for ComfyUI-VideoHelperSuite
         libglib2.0-0 libgl1 libglx-mesa0 fonts-dejavu-core fontconfig \
+        libsm6 libxext6 libxrender1 \
     && rm -rf /var/lib/apt/lists/*
 
 # Configure application user
@@ -28,6 +29,35 @@ RUN set -eux; \
         --create-home --home-dir "$WORKDIR" \
         --shell /bin/bash --no-log-init comfy
 ENV COMFYUI_REF=$COMFYUI_REF
+# --- Built-in virtual environment (fast, reproducible) ---
+WORKDIR $WORKDIR
+RUN python3 -m venv /opt/venv
+ENV PATH="/opt/venv/bin:${PATH}" \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PIP_NO_CACHE_DIR=0 \
+    XDG_CACHE_HOME=/workspace/.cache \
+    HF_HOME=/workspace/.cache/huggingface \
+    TORCH_HOME=/workspace/.cache/torch \
+    PIP_CACHE_DIR=/workspace/.cache/pip \
+    # CUDA JIT cache in RAM (tmpfs)
+    CUDA_CACHE_PATH=/tmp/ComputeCache \
+    # Single temp location pointing to /tmp (tmpfs) – Compose can override
+    TMPDIR=/tmp
+
+# Prepare shared cache and temporary directories
+RUN mkdir -p /workspace/.cache /tmp && \
+    # One temp path, two entrances: /workspace/temp -> /tmp (same tmpfs)
+    ln -sfn /tmp /workspace/temp
+
+# Install Torch/cu128 & xformers during the build (not in the entrypoint)
+RUN pip install --upgrade pip wheel setuptools && \
+    pip install \
+      torch==2.8.0 torchvision==0.23.0 torchaudio==2.8.0 \
+      --index-url https://download.pytorch.org/whl/cu128 && \
+    pip install xformers==0.0.27.post2 sageattention
+
+RUN chown -R "${UID}:${GID}" /opt/venv "$WORKDIR"
+
 USER comfy
 WORKDIR $WORKDIR
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -47,12 +47,6 @@ if [ ! -x "$VENV_PATH/bin/pip" ]; then
   python3 -m venv "$VENV_PATH"
 fi
 
-$VENV_PATH/bin/pip install --upgrade pip
-$VENV_PATH/bin/pip install --no-cache-dir \
-  --extra-index-url https://download.pytorch.org/whl/cu124 \
-  torch==2.5.1+cu124 torchvision==0.20.1+cu124 \
-  torchaudio==2.5.1+cu124 xformers==0.0.28.post3 sageattention
-
 # requirements without torch and xformers, to ensure our specific versions
 grep -vE 'torch|torchvision|torchaudio|xformers' \
      ComfyUI/requirements.txt >/tmp/req.txt


### PR DESCRIPTION
## Summary
- upgrade the CUDA runtime base to 12.8.1 on Ubuntu 24.04 and install the extra X11 libraries required by OpenCV
- create and populate the image virtualenv during build with centralized cache/temp paths and preinstall the CUDA 12.8 PyTorch stack plus xformers
- streamline the entrypoint and compose file to rely on the baked venv and use tmpfs for temporary storage instead of bind mounts

## Testing
- not run (docker not available in environment)


------
https://chatgpt.com/codex/tasks/task_e_68f4bb61c9b4832384c0a365df271ff7