### PR TITLE
Separate cache and temp configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,22 +14,22 @@ services:
       - ./custom_nodes:/workspace/custom_nodes
       - ./models:/workspace/models
       - ./output:/workspace/output
-      # persist all your settings & extra nodes
+      # Persist all user settings and extra nodes
       - ./settings:/app/ComfyUI/user/default:rw
-      # persist just your saved flows (overrides the workflows/ in default)
+      # Persist only saved workflows (overrides the default workflows/ folder)
       - ./flows:/app/ComfyUI/user/default/workflows:rw
-      # Caches persistent
+      # Keep caches on disk for reproducibility and to save RAM
       - ./cache:/workspace/.cache
-      - ./nv:/root/.nv
     tmpfs:
       - /workspace/input:size=1G,mode=1777
       - /tmp:size=8G,mode=1777
+    shm_size: "2g"  # Help ffmpeg/OpenCV with large jobs
     environment:
-      # Caches
+      # Cache directories on the persistent volume
       - XDG_CACHE_HOME=/workspace/.cache
       - HF_HOME=/workspace/.cache/huggingface
-      - TRANSFORMERS_CACHE=/workspace/.cache/huggingface/transformers
       - HUGGINGFACE_HUB_CACHE=/workspace/.cache/huggingface/hub
+      - TRANSFORMERS_CACHE=/workspace/.cache/huggingface/transformers
       - TORCH_HOME=/workspace/.cache/torch
       - PIP_CACHE_DIR=/workspace/.cache/pip
     deploy:

--- a/dockerfile
+++ b/dockerfile
@@ -35,14 +35,9 @@ RUN python3 -m venv /opt/venv
 ENV PATH="/opt/venv/bin:${PATH}" \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \
     PIP_NO_CACHE_DIR=0 \
-    XDG_CACHE_HOME=/workspace/.cache \
-    HF_HOME=/workspace/.cache/huggingface \
-    TORCH_HOME=/workspace/.cache/torch \
-    PIP_CACHE_DIR=/workspace/.cache/pip \
-    # CUDA JIT cache in RAM (tmpfs)
+    TMPDIR=/tmp \
     CUDA_CACHE_PATH=/tmp/ComputeCache \
-    # Single temp location pointing to /tmp (tmpfs) – Compose can override
-    TMPDIR=/tmp
+    CUDA_CACHE_MAXSIZE=536870912
 
 # Prepare shared cache and temporary directories
 RUN mkdir -p /workspace/.cache /tmp && \


### PR DESCRIPTION
## Summary
- scope the Docker image to only define temporary and CUDA cache environment variables
- configure cache directories on the compose service with documentation in English
- remove the unused NV cache bind and add a shared memory size hint for large jobs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f4c4f7ed888323a8d4ea79cea3a871