### PR TITLE
Ensure WORKDIR is only set after switching users

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -33,8 +33,15 @@ RUN set -eux; \
                --shell /bin/bash --no-log-init comfy; \
     fi
 ENV COMFYUI_REF=$COMFYUI_REF
+# Prepare writable paths before switching users
+RUN install -d -m 0755 -o "${UID}" -g "${GID}" /opt/venv "${WORKDIR}" "${WORKDIR}/.cache" /tmp /tmp/Input
+
+# Continue as numeric user from this point forward
+USER ${UID}:${GID}
+ENV HOME=${WORKDIR}
+WORKDIR ${WORKDIR}
+
 # --- Built-in virtual environment (fast, reproducible) ---
-WORKDIR $WORKDIR
 RUN python3 -m venv /opt/venv
 ENV PATH="/opt/venv/bin:${PATH}" \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \
@@ -44,32 +51,25 @@ ENV PATH="/opt/venv/bin:${PATH}" \
     CUDA_CACHE_MAXSIZE=536870912
 
 # Install Torch/cu128 & xformers
-RUN mkdir -p /workspace/.cache
 RUN pip install --upgrade pip wheel setuptools && \
     pip install \
       torch==2.8.0 torchvision==0.23.0 torchaudio==2.8.0 \
       --index-url https://download.pytorch.org/whl/cu128 && \
     pip install xformers==0.0.27.post2 sageattention
 
-RUN chown -R "${UID}:${GID}" /opt/venv "$WORKDIR"
-
-USER comfy
-WORKDIR $WORKDIR
-
 # install ComfyUI and download reqirements (excluding already pinned ones above)
 RUN git config --global --add safe.directory /workspace/ComfyUI \
     && git clone --depth 1 https://github.com/comfyanonymous/ComfyUI.git ComfyUI
 # One temp path, two entrances: /workspace/ComfyUI/temp -> /tmp (same tmpfs)
-RUN mkdir -p /tmp /tmp/Input \
-    && ln -sfn /tmp /workspace/ComfyUI/temp \
+RUN ln -sfn /tmp /workspace/ComfyUI/temp \
     && ln -sfn /tmp/Input /workspace/ComfyUI/input
 RUN grep -vE '^(torch|torchvision|torchaudio|xformers)($|=)' ComfyUI/requirements.txt > /tmp/req.txt \
     && pip install -r /tmp/req.txt
 
 # Copy application entrypoint and dependency patches
-COPY --chown=comfy:comfy entrypoint.sh /entrypoint.sh
+COPY --chown=${UID}:${GID} entrypoint.sh /entrypoint.sh
 RUN sed -i 's/\r$//' /entrypoint.sh && chmod +x /entrypoint.sh
-COPY --chown=comfy:comfy patch-requirements.txt /patch-requirements.txt
+COPY --chown=${UID}:${GID} patch-requirements.txt /patch-requirements.txt
 ENTRYPOINT ["/usr/bin/tini","--","/entrypoint.sh"]
 EXPOSE 8188
 


### PR DESCRIPTION
## Summary
- create dirs for the user 1000 beforehand - no chown necessary
- using only ids, no named user comfy as this does not work with this base image

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f54a49ea9c8323a92bf9373ad0d8d3