### PR TITLE
Ensure writable cache, output, and custom node binds

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,27 @@ It supports both **Podman** and **Docker**, and can optionally serve the UI behi
 
 ## Directory Layout
 
-Create these directories in the repository root before starting:
+The stack persists its data through bind mounts located in the repository root:
 - `custom_nodes/`
 - `models/`
 - `output/`
-- `venv/`
+- `settings/`
+- `flows/`
+- `cache/`
+
+When you run `docker compose up` (or the `run_comfy.sh` helper), a short‑lived
+initialisation container creates these directories if they do not exist yet and
+adjusts their permissions so that the main `comfyui` service can write to them.
+You can still pre-create the directories manually if you want to fine-tune
+ownership or restrict permissions more tightly.
+
+If you want to store any of the bind-mounted directories somewhere else (for
+example on a large external disk), edit the `x-host-paths` section at the top of
+`docker-compose.yml`. Both the main service and the helper container reuse that
+single mapping, so you only have to change the path in one place. Likewise, the
+memory limit, CPU quota, and `/tmp` tmpfs size for the `comfyui` service are
+collected in the `x-comfyui-resources` mapping so they can be adjusted from a
+single place as well.
 
 ---
 
@@ -81,7 +97,9 @@ Optionally, the ComfyUI instance can be served through an `nginx` reverse proxy 
    git clone <repo-url>
    cd comfyui-podman-compose
    ```
-2. Create the required directories listed above.
+2. (Optional) Pre-create any of the directories listed above if you want to
+   control their ownership or permissions manually. Otherwise, the helper
+   container spawned by Compose will create them on demand.
 3. Start the container:
     ```bash
     ./run_comfy.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,27 +1,95 @@
+x-host-paths: &host-paths
+  custom_nodes: &host-custom_nodes
+    source: ./custom_nodes
+    read_only: false
+  models: &host-models
+    source: ./models
+  output: &host-output
+    source: ./output
+    read_only: false
+  settings: &host-settings
+    source: ./settings
+    read_only: false
+  flows: &host-flows
+    source: ./flows
+    read_only: false
+  cache: &host-cache
+    source: ./cache
+    read_only: false
+
+x-comfyui-resources: &comfyui-resources
+  mem_limit: "40g"
+  cpus: "8.0"
+  tmpfs:
+    - /tmp:size=8G,mode=1777
+
 services:
+  volume-permissions:
+    image: alpine:3.20
+    container_name: comfyui-volume-permissions
+    command: >-
+      sh -c '
+        set -eu
+        for dir in custom_nodes models output settings flows cache; do
+          install -d -m 0777 "/mnt/${dir}"
+        done
+      '
+    volumes:
+      - type: bind
+        <<: *host-custom_nodes
+        target: /mnt/custom_nodes
+      - type: bind
+        <<: *host-models
+        target: /mnt/models
+      - type: bind
+        <<: *host-output
+        target: /mnt/output
+      - type: bind
+        <<: *host-settings
+        target: /mnt/settings
+      - type: bind
+        <<: *host-flows
+        target: /mnt/flows
+      - type: bind
+        <<: *host-cache
+        target: /mnt/cache
+    restart: "no"
+
   comfyui:
     image: comfyui:latest
     container_name: comfyui
+    <<: *comfyui-resources
     build:
       context: .
       dockerfile: dockerfile
     user: "1000:1000"
     expose:
       - "8188"
-    mem_limit: "40g"
-    cpus: "8.0"
+    depends_on:
+      volume-permissions:
+        condition: service_completed_successfully
     volumes:
-      - ./custom_nodes:/workspace/ComfyUI/custom_nodes
-      - ./models:/workspace/ComfyUI/models
-      - ./output:/workspace/ComfyUI/output
+      - type: bind
+        <<: *host-custom_nodes
+        target: /workspace/ComfyUI/custom_nodes
+      - type: bind
+        <<: *host-models
+        target: /workspace/ComfyUI/models
+      - type: bind
+        <<: *host-output
+        target: /workspace/ComfyUI/output
       # Persist all user settings and extra nodes
-      - ./settings:/workspace/ComfyUI/user/default:rw
+      - type: bind
+        <<: *host-settings
+        target: /workspace/ComfyUI/user/default
       # Persist only saved workflows (overrides the default workflows/ folder)
-      - ./flows:/workspace/ComfyUI/user/default/workflows:rw
+      - type: bind
+        <<: *host-flows
+        target: /workspace/ComfyUI/user/default/workflows
       # Keep caches on disk for reproducibility and to save RAM
-      - ./cache:/workspace/.cache
-    tmpfs:
-      - /tmp:size=8G,mode=1777
+      - type: bind
+        <<: *host-cache
+        target: /workspace/.cache
     shm_size: "2g"  # Help ffmpeg/OpenCV with large jobs
     environment:
       # Cache directories on the persistent volume


### PR DESCRIPTION
## Summary
- mark the custom_nodes, output, and cache host-path anchors as explicitly read/write
- keep the helper and main services inheriting the correct permissions through the shared mappings

## Testing
- not run (container runtime unavailable in CI environment)


------
https://chatgpt.com/codex/tasks/task_e_68fbe46bd688832390d75f7d86d25c2f