### PR TITLE
Handle sidecar directory ownership setup failures

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,13 @@ services:
       sh -c '
         set -eu
         for dir in custom_nodes models output settings flows cache; do
-          install -d -m 0777 "/mnt/${dir}"
+          target="/mnt/${dir}"
+          if ! install -d -m 0777 "${target}"; then
+            echo "install failed for ${target}, attempting fallback" >&2
+            mkdir -p "${target}"
+            chmod 0777 "${target}"
+          fi
+          chown -R 1000:1000 "${target}"
         done
       '
     volumes:


### PR DESCRIPTION
## Summary
- ensure the volume-permissions sidecar falls back to mkdir/chmod if install fails
- enforce ownership of shared directories by chowning them to uid/gid 1000

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fbee9a85208323a7b9a1420be2b169