### PR TITLE
Fix volume permissions command variable expansion

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,13 +31,13 @@ services:
       sh -c '
         set -eu
         for dir in custom_nodes models output settings flows cache; do
-          target="/mnt/${dir}"
-          if ! install -d -m 0777 "${target}"; then
-            echo "install failed for ${target}, attempting fallback" >&2
-            mkdir -p "${target}"
-            chmod 0777 "${target}"
+          target="/mnt/$${dir}"
+          if ! install -d -m 0777 "$${target}"; then
+            echo "install failed for $${target}, attempting fallback" >&2
+            mkdir -p "$${target}"
+            chmod 0777 "$${target}"
           fi
-          chown -R 1000:1000 "${target}"
+          chown -R 1000:1000 "$${target}"
         done
       '
     volumes:


### PR DESCRIPTION
## Summary
- escape shell variables in the volume-permissions helper so docker compose does not strip them
- ensure install fallback handles the intended mount paths

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fbf2a961bc832381a516c7a977ff8c